### PR TITLE
README: fix broken link and add .md extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 Basic Installation
 ===================
-Check www.severalnines.com/sizer for the latest instructions.
+Check [sizer](https://severalnines.com/sizer-capacity-planning-tool) for the latest instructions.
 in short:
 edit the Makefile and set MYSQL_BASEDIR
 $ make
 
 Redhat/Centos/Suse using RPM:
 You must install the MySQL-Cluster-devel (contains header files) package before running make:
-   sudo rpm -Uvh mysqlcluster-72-rpm/cluster/repo/MySQL-Cluster-devel-gpl-7.2.8-1.el6.x86_64.rpm 
+   sudo rpm -Uvh mysqlcluster-72-rpm/cluster/repo/MySQL-Cluster-devel-gpl-7.2.8-1.el6.x86_64.rpm
 
 
 Bugs
@@ -17,6 +17,3 @@ https://github.com/severalnines/sizer/issues
 Support and Pricing
 ===================
 Contact sales@severalnines.com for more information
-
-
-


### PR DESCRIPTION
The previous link to sizer web page on severalnines.com has changed
so I cahnged it here in the README file.
I also added .md extension to the file to be identified by github as
markdown file and rendered as markdown

closes #2 